### PR TITLE
[ADD]RentalObject 대여가능 여부

### DIFF
--- a/helloDaeyeo/src/main/java/com/daeyeo/helloDaeyeo/controller/RentalController.java
+++ b/helloDaeyeo/src/main/java/com/daeyeo/helloDaeyeo/controller/RentalController.java
@@ -3,15 +3,11 @@ package com.daeyeo.helloDaeyeo.controller;
 import com.daeyeo.helloDaeyeo.dto.category.MainCategoryDto;
 import com.daeyeo.helloDaeyeo.dto.category.SubCategoryDto;
 import com.daeyeo.helloDaeyeo.dto.rental.*;
-import com.daeyeo.helloDaeyeo.embedded.Address;
-import com.daeyeo.helloDaeyeo.entity.RentalObject;
-import com.daeyeo.helloDaeyeo.entity.SubCategory;
 import com.daeyeo.helloDaeyeo.repository.MemberRepository;
 import com.daeyeo.helloDaeyeo.service.MainCategoryService;
 import com.daeyeo.helloDaeyeo.service.MemberService;
 import com.daeyeo.helloDaeyeo.service.RentalObjectService;
 import com.daeyeo.helloDaeyeo.service.SubCategoryService;
-import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -21,7 +17,8 @@ import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.*;
-
+import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.List;
 
 @Controller
@@ -48,7 +45,15 @@ public class RentalController {
 
         model.addAttribute("categories", categories);
         model.addAttribute("searchSpec", specDto);
-        model.addAttribute("rentalObjects", rentalObjectDtos);
+
+        List<DummyClass> rentalObjectList = new ArrayList<>();
+
+        for (RentalObjectDto rentalObjectDto : rentalObjectDtos.getContent()) {
+            boolean isAble = LocalDate.now().compareTo(rentalObjectDto.getApplicationPeriod().getEndDate()) <= 0;
+
+            rentalObjectList.add(new DummyClass(rentalObjectDto,isAble));
+        }
+        model.addAttribute("isAbleList",rentalObjectList);
 
         return "rental/rentalList";
     }
@@ -113,4 +118,29 @@ public class RentalController {
         return send;
     }
      */
+}
+class DummyClass{
+    private RentalObjectDto dto;
+    private boolean isAble;
+
+    DummyClass(RentalObjectDto dto, boolean isAble){
+        this.dto = dto;
+        this.isAble = isAble;
+    }
+
+    public RentalObjectDto getDto() {
+        return dto;
+    }
+
+    public void setDto(RentalObjectDto dto) {
+        this.dto = dto;
+    }
+
+    public boolean isAble() {
+        return isAble;
+    }
+
+    public void setAble(boolean able) {
+        isAble = able;
+    }
 }

--- a/helloDaeyeo/src/main/resources/templates/rental/rentalList.html
+++ b/helloDaeyeo/src/main/resources/templates/rental/rentalList.html
@@ -100,10 +100,16 @@
             </h5>
             <div class="object-form">
                 <ul id="rental-list" class="list-type">
-                    <li th:each="rentalObject : ${rentalObjects}">
-                        <a href="#" th:data-id="${rentalObject.objectIndex}" class="rental-object">
+                    <li th:each="isAbleList: ${isAbleList}">
+                        <a href="#" th:data-id="${isAbleList.dto.objectIndex}" class="rental-object">
+
                             <div class="img_box">
-                                <span class="board-state">대여가능</span>
+                                <div th:if="${isAbleList.isAble}">
+                                    <span class="board-state">대여가능</span>
+                                </div>
+                                <div th:unless="${!isAbleList.isAble}">
+                                    <span class="board-state">대여 불가능</span>
+                                </div>
                                 <img th:src="@{/img/rental/image_icon.png}" alt="사진">
                             </div>
                             <div class="description">
@@ -114,25 +120,25 @@
                                         <li class="breadcrumb-item" th:text="${rentalObject.scId}"></li>
                                     </ol>
                                 </div>
-                                <div class="title" th:text="${rentalObject.objectName}"></div>
+                                <div class="title" th:text="${isAbleList.dto.objectName}"></div>
                                 <ul class="obj_info">
                                     <li>
                                         <span class="place icon">장소</span>
-                                        <span class="obj" th:text="${rentalObject.address.detailAddress}"></span>
+                                        <span class="obj" th:text="${isAbleList.dto.address.detailAddress}"></span>
                                     </li>
                                     <li>
                                         <span class="price icon">이용요금</span>
-                                        <span class="obj" th:text="${rentalObject.usageFee}"></span>
+                                        <span class="obj" th:text="${isAbleList.dto.usageFee}"></span>
                                     </li>
                                     <li>
                                         <span class="reception_period icon">접수기간</span>
-                                        <span th:text="${rentalObject.applicationPeriod.startDate}
-                                        + ' ~ ' + ${rentalObject.applicationPeriod.endDate}"></span>
+                                        <span th:text="${isAbleList.dto.applicationPeriod.startDate}
+                                        + ' ~ ' + ${isAbleList.dto.applicationPeriod.endDate}"></span>
                                     </li>
                                     <li>
                                         <span class="use_period icon">이용기간</span>
-                                        <span th:text="${rentalObject.usagePeriod.startDate}
-                                        + ' ~ ' + ${rentalObject.usagePeriod.endDate}"></span>
+                                        <span th:text="${isAbleList.dto.usagePeriod.startDate}
+                                        + ' ~ ' + ${isAbleList.dto.usagePeriod.endDate}"></span>
                                     </li>
                                 </ul>
                             </div>


### PR DESCRIPTION
* ApplicationPeriod가 정상적으로 들어왔을 시에 컨트롤러 로직에서 대여가능 여부 판단하여 List객체에 넣어줌 
    * 이 과정에서 Dto를 건드리지 않기 위해서 DummyClass를 innerClass로 만들어서 사용함(이 부분은 얘기를 해보자)
    ```java
    class DummyClass{
    private RentalObjectDto dto;
    private boolean isAble;

    DummyClass(RentalObjectDto dto, boolean isAble){
        this.dto = dto;
        this.isAble = isAble;
    }

    public RentalObjectDto getDto() {
        return dto;
    }

    public void setDto(RentalObjectDto dto) {
        this.dto = dto;
    }

    public boolean isAble() {
        return isAble;
    }

    public void setAble(boolean able) {
        isAble = able;
    }
    ```
* rentalList.html은 바뀐 respone Model에 맞춰서 isAbleList로 교체
    ```html
    <li th:each="isAbleList: ${isAbleList}">
        <a href="#" th:data-id="${isAbleList.dto.objectIndex}" class="rental-object">
        // ...
    </a></li>
    ```
tobe: endDate기반으로 대여가능여부를 판단하여 넣었지만 startDate가 아직 오지 않은 경우를 대비하지 않음.